### PR TITLE
Enhance appointment and patient management

### DIFF
--- a/frontend/src/components/AppointmentDetailModal.jsx
+++ b/frontend/src/components/AppointmentDetailModal.jsx
@@ -1,0 +1,100 @@
+import { Fragment, useState } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import { format } from 'date-fns';
+import { useCancelAppointment } from '../hooks/useAppointments';
+import { useQueryClient } from '@tanstack/react-query';
+
+export default function AppointmentDetailModal({ appointment, onClose }) {
+  const [cancelling, setCancelling] = useState(false);
+  const cancelMutation = useCancelAppointment();
+  const queryClient = useQueryClient();
+
+  if (!appointment) return null;
+
+  const isFuture = new Date(appointment.startAt) > new Date();
+
+  const handleCancel = async () => {
+    try {
+      setCancelling(true);
+      await cancelMutation.mutateAsync({ appointmentId: appointment.id });
+      await queryClient.invalidateQueries({ queryKey: ['patient', appointment.patientId] });
+      onClose();
+    } catch (err) {
+      console.error('Cancel failed', err);
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  return (
+    <Transition appear show={true} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black bg-opacity-25" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+                <div className="flex items-center justify-between mb-4">
+                  <Dialog.Title className="text-lg font-medium text-gray-900">Appointment Details</Dialog.Title>
+                  <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+                    <XMarkIcon className="w-6 h-6" />
+                  </button>
+                </div>
+
+                <div className="space-y-2 mb-6">
+                  <p className="text-sm text-gray-700">
+                    <span className="font-medium">Date:</span> {format(new Date(appointment.startAt), 'PPP p')}
+                  </p>
+                  <p className="text-sm text-gray-700">
+                    <span className="font-medium">Doctor:</span> {appointment.doctor?.name}
+                  </p>
+                  <p className="text-sm text-gray-700">
+                    <span className="font-medium">Session:</span> {appointment.sessionType?.name}
+                  </p>
+                  <p className="text-sm text-gray-700">
+                    <span className="font-medium">Status:</span> {appointment.status}
+                  </p>
+                  {appointment.notes && (
+                    <p className="text-sm text-gray-700">
+                      <span className="font-medium">Notes:</span> {appointment.notes}
+                    </p>
+                  )}
+                </div>
+
+                {isFuture && appointment.status !== 'cancelled' && (
+                  <button
+                    onClick={handleCancel}
+                    disabled={cancelling}
+                    className="w-full inline-flex justify-center rounded-md border border-transparent bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2"
+                  >
+                    {cancelling ? 'Cancelling...' : 'Cancel Appointment'}
+                  </button>
+                )}
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/frontend/src/components/BookingModal.jsx
+++ b/frontend/src/components/BookingModal.jsx
@@ -10,6 +10,7 @@ import { usePatients, useCreatePatient } from '../hooks/usePatients';
 export default function BookingModal() {
   const isOpen = useUIStore(state => state.bookingModalOpen);
   const selectedDate = useUIStore(state => state.selectedDate);
+  const setSelectedDate = useUIStore(state => state.setSelectedDate);
   const setBookingModalOpen = useUIStore(state => state.setBookingModalOpen);
   
   const [patientQuery, setPatientQuery] = useState('');
@@ -17,6 +18,7 @@ export default function BookingModal() {
 
   const { data: patients = [] } = usePatients(patientQuery);
   const { data: availableDoctors = [] } = useAvailableDoctors(selectedDate, selectedDate?.getHours());
+  const timeSlots = Array.from({ length: 10 }, (_, i) => i + 8);
   const createAppointment = useCreateAppointment();
   const createPatient = useCreatePatient();
 
@@ -119,10 +121,38 @@ export default function BookingModal() {
                   </button>
                 </div>
 
-                <div className="mb-6 p-4 bg-gradient-to-r from-primary-50 to-blue-50 rounded-lg border border-primary-100">
-                  <p className="text-sm font-medium text-primary-900">
-                    {format(selectedDate, 'EEEE, MMMM do, yyyy')} at {format(selectedDate, 'h:mm a')}
-                  </p>
+                <div className="mb-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Date</label>
+                    <input
+                      type="date"
+                      value={format(selectedDate, 'yyyy-MM-dd')}
+                      onChange={(e) => {
+                        const newDate = new Date(e.target.value);
+                        newDate.setHours(selectedDate.getHours(), 0, 0, 0);
+                        setSelectedDate(newDate);
+                      }}
+                      className="input"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Time</label>
+                    <select
+                      value={selectedDate.getHours()}
+                      onChange={(e) => {
+                        const newDate = new Date(selectedDate);
+                        newDate.setHours(parseInt(e.target.value), 0, 0, 0);
+                        setSelectedDate(newDate);
+                      }}
+                      className="input"
+                    >
+                      {timeSlots.map(hour => (
+                        <option key={hour} value={hour}>
+                          {format(new Date().setHours(hour, 0, 0, 0), 'h:mm a')}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
                 </div>
 
                 <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">

--- a/frontend/src/components/BookingModal.jsx
+++ b/frontend/src/components/BookingModal.jsx
@@ -26,9 +26,7 @@ export default function BookingModal() {
     defaultValues: {
       doctorId: '',
       sessionTypeId: '',
-      notes: '',
-      recurrence: false,
-      endDate: ''
+      notes: ''
     }
   });
 
@@ -39,7 +37,7 @@ export default function BookingModal() {
     ? patients
     : patients.filter(patient =>
         patient.name.toLowerCase().includes(patientQuery.toLowerCase()) ||
-        patient.phone?.includes(patientQuery) || true
+        patient.phone?.includes(patientQuery)
       );
 
   const onClose = () => {
@@ -72,12 +70,6 @@ export default function BookingModal() {
       };
 
       await createAppointment.mutateAsync(appointmentData);
-      
-      // Handle recurrence if selected
-      if (data.recurrence && data.endDate) {
-        // TODO: Implement recurrence creation
-        console.log('Creating recurrence until', data.endDate);
-      }
 
       onClose();
     } catch (error) {
@@ -332,37 +324,6 @@ export default function BookingModal() {
                       rows={3}
                       placeholder="Appointment notes"
                     />
-                  </div>
-
-                  <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                    <div className="flex items-center space-x-2">
-                      <input
-                        type="checkbox"
-                        {...register('recurrence')}
-                        className="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
-                      />
-                      <label className="text-sm text-gray-700">
-                        Reserve always (weekly recurrence)
-                      </label>
-                    </div>
-
-                    {watch('recurrence') && (
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          End Date
-                        </label>
-                        <input
-                          {...register('endDate', { 
-                            required: watch('recurrence') ? 'End date is required for recurrence' : false 
-                          })}
-                          type="date"
-                          className="input"
-                        />
-                        {errors.endDate && (
-                          <p className="mt-1 text-sm text-red-600">{errors.endDate.message}</p>
-                        )}
-                      </div>
-                    )}
                   </div>
 
                   <div className="flex flex-col sm:flex-row justify-end space-y-2 sm:space-y-0 sm:space-x-3 pt-4">

--- a/frontend/src/hooks/usePatients.js
+++ b/frontend/src/hooks/usePatients.js
@@ -81,3 +81,21 @@ export const useRecordPayment = () => {
     }
   });
 };
+
+export const useDeleteFutureAppointments = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (patientId) => {
+      const response = await api.delete(`/patients/${patientId}/appointments/future`);
+      return response.data;
+    },
+    onSuccess: (data, patientId) => {
+      queryClient.invalidateQueries({ queryKey: ['patient', patientId] });
+      toast.success('Future appointments deleted');
+    },
+    onError: (error) => {
+      toast.error(error.response?.data?.error || 'Failed to delete appointments');
+    }
+  });
+};

--- a/frontend/src/hooks/useSessionTypes.js
+++ b/frontend/src/hooks/useSessionTypes.js
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../utils/api';
+
+export const useSessionTypes = () => {
+  return useQuery({
+    queryKey: ['sessionTypes'],
+    queryFn: async () => {
+      const response = await api.get('/session-types');
+      return response.data;
+    }
+  });
+};
+
+export default useSessionTypes;

--- a/frontend/src/pages/Doctors.jsx
+++ b/frontend/src/pages/Doctors.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { PlusIcon, UserIcon, TrashIcon, PencilIcon } from '@heroicons/react/24/outline';
 import { useDoctors, useCreateDoctor, useUpdateDoctor, useAddDoctorSession, useUpdateDoctorSession, useDeleteDoctorSession } from '../hooks/useDoctors';
+import { useSessionTypes } from '../hooks/useSessionTypes';
 import { useAuthStore } from '../stores/auth';
 import { useForm } from 'react-hook-form';
 import { useQueryClient } from '@tanstack/react-query';
@@ -24,12 +25,7 @@ export default function Doctors() {
   const { register, handleSubmit, reset, setValue, formState: { errors } } = useForm();
   const { register: registerSession, handleSubmit: handleSessionSubmit, reset: resetSession, setValue: setSessionValue, formState: { errors: sessionErrors } } = useForm();
 
-  // Use actual session type IDs from database
-  const sessionTypes = [
-    { id: 'cmexe8yrf0000fwe7goopy5qg', name: 'Follow-up', defaultPrice: 100 },
-    { id: 'cmexe8yrm0002fwe7tx5ljdrc', name: 'Consultation', defaultPrice: 150 },
-    { id: 'cmexe8yrm0001fwe78hdk4aw8', name: 'Procedure', defaultPrice: 300 }
-  ];
+  const { data: sessionTypes = [] } = useSessionTypes();
 
   const onSubmit = async (data) => {
     try {
@@ -297,7 +293,7 @@ export default function Doctors() {
                     onChange={(e) => {
                       const selectedType = sessionTypes.find(type => type.id === e.target.value);
                       if (selectedType) {
-                        setSessionValue('customPrice', selectedType.defaultPrice);
+                        setSessionValue('customPrice', selectedType.price);
                       }
                       registerSession('sessionTypeId').onChange(e);
                     }}
@@ -307,7 +303,7 @@ export default function Doctors() {
                       .filter(type => !managingSessions.sessionLists?.some(sl => sl.sessionTypeId === type.id))
                       .map(type => (
                         <option key={type.id} value={type.id}>
-                          {type.name} (Default: ${type.defaultPrice})
+                          {type.name} (Default: ${type.price})
                         </option>
                       ))
                     }

--- a/frontend/src/pages/PatientDetail.jsx
+++ b/frontend/src/pages/PatientDetail.jsx
@@ -728,8 +728,13 @@ export default function PatientDetail() {
                     <button
                       type="button"
                       onClick={async () => {
-                        await deleteFutureAppointments.mutateAsync(patientId);
-                        setShowDeleteDialog(false);
+                        try {
+                          await deleteFutureAppointments.mutateAsync(patientId);
+                          setShowDeleteDialog(false);
+                        } catch (error) {
+                          console.error('Failed to delete future appointments:', error);
+                          alert('Failed to delete future appointments');
+                        }
                       }}
                       disabled={deleteFutureAppointments.isPending}
                       className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50"


### PR DESCRIPTION
## Summary
- Load session types from backend when assigning doctor services
- Allow appointment booking for any date via date and time selectors
- Expand patient page with appointment list, detail modal, and bulk future-appointment deletion
- Add API endpoint to remove all future appointments for a patient

## Testing
- `npm test` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68c13a3c165c83268d039d0abb80ef5c